### PR TITLE
Fixed an issue where multiple links in the documentation were not working.

### DIFF
--- a/Documentation~/TableOfContents.md
+++ b/Documentation~/TableOfContents.md
@@ -1,3 +1,3 @@
-* [About the Editor Iteration Profiler](index)
-* [Using the Editor Iteration Profiler](editor-iteration-profiler)
-* [Exporting data](exporting-data)
+* [About the Editor Iteration Profiler](index.md)
+* [Using the Editor Iteration Profiler](editor-iteration-profiler.md)
+* [Exporting data](exporting-data.md)

--- a/Documentation~/editor-iteration-profiler.md
+++ b/Documentation~/editor-iteration-profiler.md
@@ -16,5 +16,5 @@ The controls for the EIP are in the toolbar at the top of the window. You can us
 |**Clear**|Removes all recorded events from the EIP.|
 |**Collapse All**|Recursively collapses all events in the table.|
 |**Print to Console**|Logs all data to the console in a plain text format.|
-|**Export**|Export all of the data in the EIP. You can choose from HTML, JSON, CSV, Plaintext, or HTML Performance Report. For more information on this see the documentation on [Exporting data](exporting-data).|
-|**Export Profiler Data**|Export the data in the EIP for the selected Profiler frame, or choose a range of Profiler frames to export the EIP data for. When you select **Multiple Frames**, the beginning and end limits are inclusive. For more information, see the documentation on [How to export data](exporting-data#how-to-export-data)|
+|**Export**|Export all of the data in the EIP. You can choose from HTML, JSON, CSV, Plaintext, or HTML Performance Report. For more information on this see the documentation on [Exporting data](exporting-data.md).|
+|**Export Profiler Data**|Export the data in the EIP for the selected Profiler frame, or choose a range of Profiler frames to export the EIP data for. When you select **Multiple Frames**, the beginning and end limits are inclusive. For more information, see the documentation on [How to export data](exporting-data#how-to-export-data.md)|

--- a/Documentation~/exporting-data.md
+++ b/Documentation~/exporting-data.md
@@ -2,11 +2,11 @@
 
 You can export the data that the Editor Iteration Profiler captures in several different file formats so that you can inspect the performance of your application in greater detail. The following file formats are available:
 
-* [.html](exporting-data#html)
-* [.json](exporting-data#json) (for [chrome tracing](http://www.chromium.org/developers/how-tos/trace-event-profiling-tool))
-* [.csv](exporting-data#csv)
-* [Plain text](exporting-data#plain-text)
-* [HTML Performance Report](exporting-data#html-report)
+* [.html](exporting-data#html.md)
+* [.json](exporting-data#json.md) (for [chrome tracing](http://www.chromium.org/developers/how-tos/trace-event-profiling-tool))
+* [.csv](exporting-data#csv.md)
+* [Plain text](exporting-data#plain-text.md)
+* [HTML Performance Report](exporting-data#html-report.md)
 
 <a name="how-to"></a>
 

--- a/Documentation~/index.md
+++ b/Documentation~/index.md
@@ -11,7 +11,7 @@ During these iterations, the Profiler also monitors Asset import time.
 
 The EIP saves all of this information in a separate window which you can then use to navigate through the data the Profiler produces. What’s more, the data that the EIP collects persists for the lifetime of the Editor, unlike the built-in Profiler which is limited to storing a set number of frames. 
 
-You can then [export the captured data](exporting-data) to either HTML, JSON, CSV, or plain text format. In addition to these formats, you can export the data to a HTML Performance Report, which groups the data together to make it easier to see areas you can optimize.
+You can then [export the captured data](exporting-data.md) to either HTML, JSON, CSV, or plain text format. In addition to these formats, you can export the data to a HTML Performance Report, which groups the data together to make it easier to see areas you can optimize.
 
 ## Preview package
 This package is available as a preview, so it is not ready for production use. The features and documentation in this package might change before it is verified for release.


### PR DESCRIPTION
Parent Link:- https://github.com/Unity-Technologies/com.unity.editoriterationprofiler/tree/master/Documentation~
I saw 8-10 non-working links in the whole documentation, to which I noticed there was a missing ".md" in every line which causes error 404.