### PR TITLE
Add a metafile for README.md

### DIFF
--- a/README.md.meta
+++ b/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 41ae1fb9d1a93684bb23091b2c54ad2b
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
When the readme was added a few days ago, it didn't have a .meta with it, so importing spits an error because of the lack of meta. Makes sense to include one just so importing can be clean!